### PR TITLE
deprecation warnings when running unittests

### DIFF
--- a/source/std/allocator.d
+++ b/source/std/allocator.d
@@ -4399,6 +4399,8 @@ class CAllocatorImpl(Allocator) : CAllocator
     static if (stateSize!Allocator) Allocator impl;
     else alias impl = Allocator.it;
 
+override:
+
     /// Returns $(D impl.alignment).
     @property uint alignment()
     {


### PR DESCRIPTION
When running unittests with `dub -build=unittest -config=unittest` there are a lot of deprecation warnings about implicit overrides.
